### PR TITLE
docs: add vuepress-plugin-netlify-functions

### DIFF
--- a/v2.md
+++ b/v2.md
@@ -95,6 +95,7 @@
 - [@goy/vuepress-plugin-svg-icons](https://github.com/ntnyq/vuepress-plugin-svg-icons): A VuePress plugin for managing svg icons via svg sprite
 - [vuepress-plugin-social-share](https://github.com/ntnyq/vuepress-plugin-social-share/tree/next): A VuePress plugin which provides social sharing services
 - [vuepress-plugin-iconify](https://github.com/ntnyq/vuepress-plugin-iconify): A VuePress v2 plugin make it easier to use icons in VuePress
+- [vuepress-plugin-netlify-functions](https://github.com/pengzhanbo/vuepress-theme-plume/tree/main/packages/plugin-netlify-functions) A vuepress v2 plugin to basis support for `Netlify functions` when you want deploy to Netlify and use Netlify functions.
 
 ## Themes
 


### PR DESCRIPTION
[vuepress-plugin-netlify-functions](https://github.com/pengzhanbo/vuepress-theme-plume/tree/main/packages/plugin-netlify-functions)
a vuepress 2 plugin to basis support for netlify functions when you want deploy to netlify and use netlify functions.